### PR TITLE
Update bots.js

### DIFF
--- a/src/bot/commands/Bots/bots.js
+++ b/src/bot/commands/Bots/bots.js
@@ -12,7 +12,11 @@ module.exports = class extends Command {
     }
 
     async run(message, [user]) {
-        let person = user ? user : message.author;
+        
+        if (!user) user = message.author;
+
+        let person = user
+
 
         if (user.bot) return;
 


### PR DESCRIPTION
After the recent issue  #155 you fixed the problem with it not showing the users bots but it still wouldn’t default to “message.author” if no user is pinged. This will fix that (tested and working)